### PR TITLE
Use initZygote instead of loadPackageParam

### DIFF
--- a/app/src/main/java/ca/gabrielcastro/butteredtoast/XposedHook.java
+++ b/app/src/main/java/ca/gabrielcastro/butteredtoast/XposedHook.java
@@ -19,6 +19,8 @@
 
 package ca.gabrielcastro.butteredtoast;
 
+import android.content.Context;
+import android.content.pm.PackageManager;
 import android.text.SpannableStringBuilder;
 import android.view.View;
 import android.view.ViewGroup;
@@ -28,17 +30,16 @@ import android.widget.Toast;
 import java.util.ArrayList;
 import java.util.List;
 
-import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.IXposedHookZygoteInit;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
-import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
-public class XposedHook  implements IXposedHookLoadPackage {
+public class XposedHook  implements IXposedHookZygoteInit {
 
 
     @Override
-    public void handleLoadPackage(final XC_LoadPackage.LoadPackageParam loadPackageParam) throws Throwable {
+    public void initZygote(StartupParam startupParam) throws Throwable {
         XposedHelpers.findAndHookMethod(Toast.class, "show", new XC_MethodHook() {
             @Override
             protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
@@ -57,7 +58,10 @@ public class XposedHook  implements IXposedHookLoadPackage {
                     TextView text = list.get(0);
                     CharSequence cs = text.getText();
                     if (cs != null) {
-                        CharSequence name = text.getContext().getPackageManager().getApplicationLabel(loadPackageParam.appInfo);
+                        Context context = (Context) XposedHelpers.getObjectField(t, "mContext");
+                        PackageManager pm = context.getPackageManager();
+                        pm.getApplicationInfo(context.getPackageName(), 0);
+                        CharSequence name = pm.getApplicationLabel(pm.getApplicationInfo(context.getPackageName(), 0));
                         SpannableStringBuilder builder = new SpannableStringBuilder(name);
                         builder.append(":\n").append(cs);
                         text.setText(builder.toString());


### PR DESCRIPTION
loadPackageParam is called for each package, so the method is probably being hooked each time a package is loaded, which is a huge waste.

This patch uses initZygote which means the method is hooked once and applies everywhere.

Please test it before merging, this project seems to have been done with Android Studio, which means it's messed up in Eclipse and eclipse can't build it :)
